### PR TITLE
upgrading compatibility up to macOS 10.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ img.jpeg
 
 .idea
 *.iml
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyscard==1.9.6
+pyscard==1.9.9
 progressbar==2.3
 pyDes==2.0.1


### PR DESCRIPTION
upgrading pyscard 1.9.6 to 1.9.9 correctly handles macOS versions older than 10.10 (including latest 10.15)